### PR TITLE
Bugfix/trim dependencies and reduce dist size

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,6 +16,8 @@
       'loglevel'    : '../../bower_components/loglevel/dist/loglevel',
       'revalidator' : '../../node_modules/revalidator/lib/revalidator'
     },
+    // these dependencies are used in the build process but not in the dist.
+    exclude  : [ 'cs', 'coffee-script' ],
     packages : [
       {
         name     : 'cs',


### PR DESCRIPTION
dists were getting huge, eliminating things we don't need to distribute, cuts library size from 1650kb -> 1100kb