### PR TITLE
fix buggy shield icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kryptnostic.js
 
-[![Build Status](https://img.shields.io/travis/kryptnostic/kryptnostic-js.svg?branch=develop)](https://travis-ci.org/kryptnostic/kryptnostic-js)
+[![Build Status](https://travis-ci.org/kryptnostic/kryptnostic-js.svg?branch=develop)](https://travis-ci.org/kryptnostic/kryptnostic-js)
 [![Bower Version](https://img.shields.io/bower/v/kryptnostic-js.svg)](http://bower.io/search/?q=kryptnostic-js)
 [![Release Version](https://img.shields.io/github/tag/kryptnostic/kryptnostic-js.svg)](https://github.com/kryptnostic/kryptnostic-js)
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main"        : "kryptnostic-crypto.js",
   "homepage"    : "https://github.com/kryptnostic/kryptnostic-js",
   "license"     : "Apache-2.0",
-  "author"      : "Ryan Buckheit <ryan@kryptnostic.com>",
   "repository": {
     "type" : "git",
     "url"  : "https://github.com/kryptnostic/kryptnostic-js.git"
@@ -19,7 +18,6 @@
     "build" : "./build.sh",
     "test"  : "./test.sh"
   },
-
   "bugs": {
     "url" : "https://github.com/kryptnostic/kryptnostic-js/issues"
   },


### PR DESCRIPTION
the img.shields.io version doesn't read branch parameters, switching to the travis version.