### PR TITLE
adds api for loading initialized users

### DIFF
--- a/js/src/http/DirectoryApi.coffee
+++ b/js/src/http/DirectoryApi.coffee
@@ -167,7 +167,7 @@ define 'kryptnostic.directory-api', [
         url    : usersInRealmUrl() + '/initialized/' + realm
         method : 'GET'
       })))
-      .then (response) =>
+      .then (response) ->
         uuids = response.data
         return uuids
 
@@ -177,7 +177,7 @@ define 'kryptnostic.directory-api', [
         url    : usersInRealmUrl() + '/' + realm
         method : 'GET'
       })))
-      .then (response) =>
+      .then (response) ->
         uuids = response.data
         return uuids
 

--- a/js/src/http/DirectoryApi.coffee
+++ b/js/src/http/DirectoryApi.coffee
@@ -161,9 +161,17 @@ define 'kryptnostic.directory-api', [
         wrappedRequest = Requests.wrapCredentials(request, { principal, credential })
         axios(wrappedRequest)
 
+    # gets users in the specified realm (initialized users only)
+    getInitializedUsers: ({ realm }) ->
+      Promise.resolve(axios(Requests.wrapCredentials({
+        url    : usersInRealmUrl() + '/initialized/' + realm
+        method : 'GET'
+      })))
+      .then (response) =>
+        uuids = response.data
+        return uuids
 
-    # gets users in the specified realm.
-    # does not include uninitialized users who have not set their primary key yet.
+    # gets users in the specified realm (includes users who have not initialized salt/publicKey)
     getUsers: ({ realm }) ->
       Promise.resolve(axios(Requests.wrapCredentials({
         url    : usersInRealmUrl() + '/' + realm
@@ -171,7 +179,6 @@ define 'kryptnostic.directory-api', [
       })))
       .then (response) =>
         uuids = response.data
-        log.info('getUsers', uuids)
-        return Promise.filter(uuids, (uuid) => @getPublicKey(uuid))
+        return uuids
 
   return DirectoryApi


### PR DESCRIPTION
add api to get initialized users
======================

fixes annoying client-side filtering calls which generated a ton of `404`'s

![notfound](http://36.media.tumblr.com/tumblr_m8w469DynA1rzupqxo1_500.jpg)