### PR TITLE
adds user client with caching

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,6 +48,7 @@
     "pako"         : "0.2.6",
     "require-cs"   : "0.5.0",
     "requirejs"    : "2.1.18",
-    "sinon-1.15.4" : "http://sinonjs.org/releases/sinon-1.15.4.js"
+    "sinon-1.15.4" : "http://sinonjs.org/releases/sinon-1.15.4.js",
+    "jscache"      : "https://raw.githubusercontent.com/monsur/jscache/ba01cdcf3e8a426782e0c297832b6c81286c9e8a/cache.js"
   }
 }

--- a/build.js
+++ b/build.js
@@ -10,6 +10,7 @@
       'bluebird'    : '../../bower_components/bluebird/js/browser/bluebird',
       'forge'       : '../../bower_components/forge/js/forge.min',
       'axios'       : '../../bower_components/axios/dist/axios.amd.min',
+      'jscache'     : '../../bower_components/jscache/index',
       'lodash'      : '../../bower_components/lodash/lodash',
       'pako'        : '../../bower_components/pako/dist/pako',
       'require'     : '../../bower_components/requirejs/require',

--- a/compile-exports.rb
+++ b/compile-exports.rb
@@ -9,6 +9,7 @@ JS_LIB_EXPORTS = [
   'axios',
   'bluebird',
   'forge',
+  'jscache',
   'lodash',
   'loglevel',
   'pako',

--- a/js/src/service/UserClient.coffee
+++ b/js/src/service/UserClient.coffee
@@ -1,0 +1,61 @@
+define 'kryptnostic.user-client', [
+  'require'
+  'bluebird'
+  'jscache'
+  'kryptnostic.logger'
+  'kryptnostic.user-directory-api'
+], (require) ->
+
+  Cache            = require 'jscache'
+  Promise          = require 'bluebird'
+  Logger           = require 'kryptnostic.logger'
+  UserDirectoryApi = require 'kryptnostic.user-directory-api'
+
+  log              = Logger.get('UserClient')
+
+  MAX_CACHED_USERS = 500
+
+  CACHE_TIMEOUT_MILLIS = 1000 * 60 * 60 * 8 # 8 hours
+
+  getCacheOpts = ->
+    return {
+      expirationAbsolute : new Date(new Date().getTime() + CACHE_TIMEOUT_MILLIS)
+      expirationSliding  : undefined
+      priority           : Cache.Priority.HIGH
+      callback           : (k, v) -> log.info('expired cached user', k)
+    }
+
+  #
+  # Service for loading user data.
+  # Author: rbuckheit
+  #
+  class UserClient
+
+    constructor: ->
+      @userDirectoryApi = new UserDirectoryApi()
+      @cache            = new Cache(MAX_CACHED_USERS)
+
+    # load full user representation
+    loadUser: (uuid) ->
+      Promise.resolve()
+      .then =>
+        cacheItem = @cache.getItem(uuid)
+
+        if cacheItem?
+          log.info('hit: returning cached user', { uuid })
+          return cacheItem
+        else
+          log.info('miss: loading user', { uuid })
+          promise = @userDirectoryApi.getUser(uuid)
+          @cache.setItem(uuid, promise, getCacheOpts())
+          return promise
+
+    # load the user's name only
+    loadName : (uuid) ->
+      Promise.resolve()
+      .then =>
+        @loadUser(uuid)
+      .then (user) ->
+        return user.name
+
+  return UserClient

--- a/js/test/service/UserClient-test.coffee
+++ b/js/test/service/UserClient-test.coffee
@@ -6,8 +6,8 @@ define [
 ], (require) ->
 
   UserClient = require 'kryptnostic.user-client'
-  sinon       = require 'sinon'
-  Promise     = require 'bluebird'
+  sinon      = require 'sinon'
+  Promise    = require 'bluebird'
 
   { userService, loadedUuids } = {}
 

--- a/js/test/service/UserClient-test.coffee
+++ b/js/test/service/UserClient-test.coffee
@@ -1,0 +1,57 @@
+define [
+  'require'
+  'sinon'
+  'bluebird'
+  'kryptnostic.user-client'
+], (require) ->
+
+  UserClient = require 'kryptnostic.user-client'
+  sinon       = require 'sinon'
+  Promise     = require 'bluebird'
+
+  { userService, loadedUuids } = {}
+
+  MOCK_USER = {
+    id   : '1-2-3-4-5-6-7-8-9'
+    name : 'christopher wallace'
+  }
+
+  beforeEach ->
+    loadedUuids = []
+    userService = new UserClient()
+    sinon.stub(userService.userDirectoryApi, 'getUser', (uuid) ->
+      loadedUuids.push(uuid)
+      return Promise.resolve(_.cloneDeep(MOCK_USER))
+    )
+
+  afterEach ->
+    userService.userDirectoryApi.getUser.restore()
+
+  describe 'UserClient', ->
+
+    describe '#loadUser', ->
+
+      it 'should load an uncached user with one api call', (done) ->
+        uuid = MOCK_USER.id
+
+        userService.loadUser(uuid)
+        .then (user) ->
+          expect(user).toEqual(MOCK_USER)
+          expect(loadedUuids.length).toBe(1)
+          expect(loadedUuids).toEqual([uuid])
+          done()
+
+      it 'should load an identical cached user without hitting the api again', (done) ->
+        uuid = MOCK_USER.id
+
+        userService.loadUser(uuid)
+        .then (user) ->
+          expect(user).toEqual(MOCK_USER)
+          expect(loadedUuids.length).toBe(1)
+          expect(loadedUuids).toEqual([uuid])
+          userService.loadUser(uuid)
+        .then (user) ->
+          expect(user).toEqual(MOCK_USER)
+          expect(loadedUuids.length).toBe(1)
+          expect(loadedUuids).toEqual([uuid])
+          done()


### PR DESCRIPTION
provide a simple utility for loading users efficiently.
essentially just moving this over from `ocelot`.