### PR TITLE
bower: update url for kryptnostic-client to new krypto-js repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,7 @@
     "forge"              : "0.6.21",
     "function-name"      : "https://raw.githubusercontent.com/kryptnostic/Function.name/6705081d59ccfc59999450694a273a15f91d09ff/Function.name.js",
     "jscache"            : "https://raw.githubusercontent.com/monsur/jscache/ba01cdcf3e8a426782e0c297832b6c81286c9e8a/cache.js",
-    "kryptnostic-client" : "https://raw.githubusercontent.com/kryptnostic/krypto/develop/krypto-lib/src/main/js/KryptnosticClient.js",
+    "kryptnostic-client" : "https://raw.githubusercontent.com/kryptnostic/krypto-js/master/KryptnosticClient.js",
     "lodash"             : "3.10.0",
     "loglevel"           : "1.3.1",
     "murmurhash3"        : "https://raw.githubusercontent.com/karanlyons/murmurHash3.js/master/murmurHash3.js",


### PR DESCRIPTION
New url for the raw github KC.js file after moving KC.js from krypto/.../main/js -> krypto-js 