### PR TITLE
search part 4

### DIFF
--- a/demo/demo-registration.js
+++ b/demo/demo-registration.js
@@ -17,7 +17,7 @@ require([
   Config.set({
     servicesUrl : 'http://localhost:8081/v1',
     heraclesUrl : 'http://localhost:8082/v1'
-  })
+  });
 
   var registrationClient      = new RegistrationClient();
   var userRegistrationRequest = new UserRegistrationRequest({

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,3 +53,12 @@ Tests named with the suffix `-test.coffee` will be picked up by the runner autom
 ## browser testing
 
 For an end-to-end demo, build using `build.sh` then open `demo/index.html` in the browser.
+
+## CORS
+
+We're working to set up a javascript build tool which will proxy requests to the backend from a single endpoint.
+In the short-term, you'll get CORS errors when running from the local file `index.html` as the demo scripts attempt to access the multiple backend servers. You can temporarily allow CORS in Chrome with the following command:
+
+```
+cd /Applications/ && open -a Google\ Chrome --args --disable-web-security
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,7 +56,7 @@ For an end-to-end demo, build using `build.sh` then open `demo/index.html` in th
 
 ## CORS
 
-We're working to set up a javascript build tool which will proxy requests to the backend from a single endpoint.
+We're working to set up a build tool which will proxy requests to the backend from a single endpoint.
 In the short-term, you'll get CORS errors when running from the local file `index.html` in development mode.
 This is because the demo scripts attempt to access the multiple backend servers.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,7 +57,10 @@ For an end-to-end demo, build using `build.sh` then open `demo/index.html` in th
 ## CORS
 
 We're working to set up a javascript build tool which will proxy requests to the backend from a single endpoint.
-In the short-term, you'll get CORS errors when running from the local file `index.html` as the demo scripts attempt to access the multiple backend servers. You can temporarily allow CORS in Chrome with the following command:
+In the short-term, you'll get CORS errors when running from the local file `index.html` in development mode.
+This is because the demo scripts attempt to access the multiple backend servers.
+
+You can temporarily allow CORS in Chrome with the following command:
 
 ```
 cd /Applications/ && open -a Google\ Chrome --args --disable-web-security

--- a/js/src/auth/AuthenticationService.coffee
+++ b/js/src/auth/AuthenticationService.coffee
@@ -57,11 +57,7 @@ define 'kryptnostic.authentication-service', [
         keypair = _keypair
         credentialProvider.store { principal, credential, keypair }
       .then ->
-        searchCredentialService.getFhePrivateKey(notifier)
-      .then ->
-        searchCredentialService.getSearchPrivateKey(notifier)
-      .then ->
-        searchCredentialService.getClientHashFunction(notifier)
+        searchCredentialService.ensureCredentialsInitialized(notifier)
       .then ->
         Promise.resolve(notifier(AuthenticationStage.COMPLETED))
       .then ->

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -11,15 +11,14 @@ define 'kryptnostic.search-credential-service', [
   'kryptnostic.search-key-serializer'
 ], (require) ->
 
-  _                   = require 'lodash'
-  Promise             = require 'bluebird'
-  Logger              = require 'kryptnostic.logger'
-  AuthenticationStage = require 'kryptnostic.authentication-stage'
-  CredentialLoader    = require 'kryptnostic.credential-loader'
-  CryptoKeyStorageApi = require 'kryptnostic.crypto-key-storage-api'
-  SearchKeySerializer = require 'kryptnostic.search-key-serializer'
-  # SearchKeyGenerator  = require 'kryptnostic.search-key-generator'
-  MockSearchKeyGenerator = require 'kryptnostic.mock.search-key-generator'
+  _                      = require 'lodash'
+  Promise                = require 'bluebird'
+  Logger                 = require 'kryptnostic.logger'
+  AuthenticationStage    = require 'kryptnostic.authentication-stage'
+  CredentialLoader       = require 'kryptnostic.credential-loader'
+  CryptoKeyStorageApi    = require 'kryptnostic.crypto-key-storage-api'
+  SearchKeySerializer    = require 'kryptnostic.search-key-serializer'
+  SearchKeyGenerator     = require 'kryptnostic.search-key-generator'
 
   log = Logger.get('SearchCredentialService')
 
@@ -66,7 +65,7 @@ define 'kryptnostic.search-credential-service', [
     constructor: ->
       @credentialLoader    = new CredentialLoader()
       @cryptoKeyStorageApi = new CryptoKeyStorageApi()
-      @searchKeyGenerator  = new MockSearchKeyGenerator()
+      @searchKeyGenerator  = new SearchKeyGenerator()
       @searchKeySerializer = new SearchKeySerializer()
 
     # initializes keys if needed.

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -110,7 +110,10 @@ define 'kryptnostic.search-credential-service', [
         Promise.props(credentialPromises)
       .then (credentialsByType) =>
         return _.mapValues(credentialsByType, (credential) =>
-          return @searchKeySerializer.decrypt(credential)
+          if _.isEmpty(credential)
+            return credential
+          else
+            return @searchKeySerializer.decrypt(credential)
         )
 
     hasInitialized: ->

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -131,7 +131,6 @@ define 'kryptnostic.search-credential-service', [
         else
           log.error('user account is in a partially initialized state')
           log.error("expected #{expectedLength} credentials but got #{credentials.length}")
-          log.error('loaded credentials were', credentials)
           throw new Error 'credentials are in a partially initialized state'
 
     initializeCredentials: ->

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -5,6 +5,7 @@ define 'kryptnostic.search-credential-service', [
   'kryptnostic.logger'
   'kryptnostic.authentication-stage'
   'kryptnostic.search-key-generator'
+  'kryptnostic.mock.search-key-generator'
   'kryptnostic.crypto-key-storage-api'
   'kryptnostic.credential-loader'
   'kryptnostic.search-key-serializer'
@@ -17,7 +18,8 @@ define 'kryptnostic.search-credential-service', [
   CredentialLoader    = require 'kryptnostic.credential-loader'
   CryptoKeyStorageApi = require 'kryptnostic.crypto-key-storage-api'
   SearchKeySerializer = require 'kryptnostic.search-key-serializer'
-  SearchKeyGenerator  = require 'kryptnostic.search-key-generator'
+  # SearchKeyGenerator  = require 'kryptnostic.search-key-generator'
+  MockSearchKeyGenerator = require 'kryptnostic.mock.search-key-generator'
 
   log = Logger.get('SearchCredentialService')
 
@@ -64,7 +66,7 @@ define 'kryptnostic.search-credential-service', [
     constructor: ->
       @credentialLoader    = new CredentialLoader()
       @cryptoKeyStorageApi = new CryptoKeyStorageApi()
-      @searchKeyGenerator  = new SearchKeyGenerator()
+      @searchKeyGenerator  = new MockSearchKeyGenerator()
       @searchKeySerializer = new SearchKeySerializer()
 
     # initializes keys if needed.
@@ -126,6 +128,7 @@ define 'kryptnostic.search-credential-service', [
 
       Promise.resolve()
       .then =>
+        log.info('generating search credentials')
         clientKeys = @searchKeyGenerator.generateClientKeys()
       .then =>
         @initializeCredential(CredentialType.FHE_PRIVATE_KEY, clientKeys, notifier)
@@ -139,6 +142,7 @@ define 'kryptnostic.search-credential-service', [
 
       Promise.resolve()
       .then ->
+        log.info('initializeCredential', credentialType.stage)
         Promise.resolve(notifier(credentialType.stage))
       .then =>
         uint8Key           = credentialType.generator(clientKeys)

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -4,7 +4,7 @@ define 'kryptnostic.search-credential-service', [
   'bluebird'
   'kryptnostic.logger'
   'kryptnostic.authentication-stage'
-  'kryptnostic.mock.kryptnostic-engine'
+  'kryptnostic.kryptnostic-engine'
   'kryptnostic.rsa-crypto-service'
   'kryptnostic.crypto-key-storage-api'
   'kryptnostic.credential-loader'
@@ -18,7 +18,7 @@ define 'kryptnostic.search-credential-service', [
   CredentialLoader      = require 'kryptnostic.credential-loader'
   RsaCryptoService      = require 'kryptnostic.rsa-crypto-service'
   CryptoKeyStorageApi   = require 'kryptnostic.crypto-key-storage-api'
-  MockKryptnosticEngine = require 'kryptnostic.mock.kryptnostic-engine'
+  MockKryptnosticEngine = require 'kryptnostic.kryptnostic-engine'
   SearchKeySerializer   = require 'kryptnostic.search-key-serializer'
 
   log = Logger.get('SearchCredentialService')

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -83,6 +83,14 @@ define 'kryptnostic.search-credential-service', [
       .then =>
         @ensureCredentialsInitialized()
       .then =>
+        @getStoredCredentials()
+
+    # private
+    # =======
+
+    getStoredCredentials: ->
+      Promise.resolve()
+      .then =>
         credentialPromises = _.mapValues(CredentialType, (credentialType) =>
           loadCredential = credentialType.getter(@cryptoKeyStorageApi)
           return loadCredential()
@@ -96,13 +104,10 @@ define 'kryptnostic.search-credential-service', [
             return @searchKeySerializer.decrypt(credential)
         )
 
-    # private
-    # =======
-
     hasInitialized: ->
       Promise.resolve()
       .then =>
-        @getAllCredentials()
+        @getStoredCredentials()
       .then (credentials) ->
         credentials    = _.compact(_.values(credentials))
         expectedLength = _.size(_.values(CredentialType))
@@ -129,7 +134,7 @@ define 'kryptnostic.search-credential-service', [
       .then =>
         @initializeCredential(CredentialType.CLIENT_HASH_FUNCTION, clientKeys, notifier)
 
-    initializeCredential: (credentialType, clientKeys) ->
+    initializeCredential: (credentialType, clientKeys, notifier) ->
       { uint8Key } = {}
 
       Promise.resolve()

--- a/js/src/auth/SearchCredentialService.coffee
+++ b/js/src/auth/SearchCredentialService.coffee
@@ -76,6 +76,8 @@ define 'kryptnostic.search-credential-service', [
     getClientHashFunction: ->
       return @getCredential('CLIENT_HASH_FUNCTION')
 
+    # TODO fix notifier
+
     # private
     # =======
 

--- a/js/src/engine/KryptnosticEngine.coffee
+++ b/js/src/engine/KryptnosticEngine.coffee
@@ -20,47 +20,42 @@ define 'kryptnostic.kryptnostic-engine', [
   #
   class KryptnosticEngine
 
-    constructor: ->
-      unless Module? and Module.KryptnosticClient?
-        log.error(ENGINE_MISSING_ERROR)
+    constructor: (@fhePrivateKey, @searchPrivateKey) ->
 
-    # client keys
-    # ===========
-
-    getFhePrivateKey: ->
-      return new Module.KryptnosticClient().getPrivateKey()
-
-    getSearchPrivateKey: ->
-      return new Module.KryptnosticClient().getSearchPrivateKey()
-
+    # client hash function
+    # generated from the given keys
+    # =============================
     getClientHashFunction: ->
-      return new Module.KryptnosticClient().getClientHashFunction()
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getClientHashFunction()
 
     # indexing
     # ========
 
-    getObjectSearchKey: (id) ->
-      return new Module.KryptnosticClient().getObjectSearchKey(id)
+    getObjectSearchKey: ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectSearchKey()
 
-    getObjectAddressFunction: (id) ->
-      return new Module.KryptnosticClient().getObjectAddressFunction(id)
+    getObjectAddressFunction: ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectAddressFunction()
 
-    getObjectConversionMatrix: (id) ->
-      return new Module.KryptnosticClient().getObjectConversionMatrix(id)
+    getObjectIndexPair: (objectSearchKey, objectAddressFunction) ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectIndexPair(objectSearchKey, objectAddressFunction)
 
-    getObjectIndexPair: (id) ->
-      return new Module.KryptnosticClient().getObjectIndexPair(id)
-
-    getObjectSharingPair: (id) ->
-      return new Module.KryptnosticClient().getObjectSharingPair(id)
+    getMetadatumAddress: (objectAddressFunction, token, objectSearchKey) ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getMetadatumAddress(objectAddressFunction, token, objectSearchKey)
 
     # search
     # ======
 
     getEncryptedSearchToken: (token) ->
-      return new Module.KryptnosticClient().getEncryptedSearchToken(token)
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getEncryptedSearchToken(token)
 
-    getTokenAddress: (token, documentKey) ->
-      throw new Error 'unimplemented'
+    # share
+    # =====
+
+    getObjectSharingPair: (objectIndexPair) ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectSharingPair(objectIndexPair)
+
+    getObjectUploadPair: (objectSharingPair) ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectUploadPair(objectSharingPair)
 
   return KryptnosticEngine

--- a/js/src/engine/KryptnosticEngine.coffee
+++ b/js/src/engine/KryptnosticEngine.coffee
@@ -22,12 +22,6 @@ define 'kryptnostic.kryptnostic-engine', [
 
     constructor: (@fhePrivateKey, @searchPrivateKey) ->
 
-    # client hash function
-    # generated from the given keys
-    # =============================
-    getClientHashFunction: ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getClientHashFunction()
-
     # indexing
     # ========
 

--- a/js/src/engine/KryptnosticEngine.coffee
+++ b/js/src/engine/KryptnosticEngine.coffee
@@ -31,8 +31,8 @@ define 'kryptnostic.kryptnostic-engine', [
     getObjectAddressMatrix: ->
       return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectAddressMatrix()
 
-    getObjectIndexPair: (objectSearchKey, objectAddressFunction) ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectIndexPair(objectSearchKey, objectAddressFunction)
+    getObjectIndexPair: (objectSearchKey, objectAddressMatrix) ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectIndexPair(objectSearchKey, objectAddressMatrix)
 
     getMetadatumAddress: (objectAddressFunction, token, objectSearchKey) ->
       return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getMetadatumAddress(objectAddressFunction, token, objectSearchKey)

--- a/js/src/engine/KryptnosticEngine.coffee
+++ b/js/src/engine/KryptnosticEngine.coffee
@@ -28,8 +28,8 @@ define 'kryptnostic.kryptnostic-engine', [
     getObjectSearchKey: ->
       return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectSearchKey()
 
-    getObjectAddressFunction: ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectAddressFunction()
+    getObjectAddressMatrix: ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectAddressMatrix()
 
     getObjectIndexPair: (objectSearchKey, objectAddressFunction) ->
       return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectIndexPair(objectSearchKey, objectAddressFunction)

--- a/js/src/engine/KryptnosticEngine.coffee
+++ b/js/src/engine/KryptnosticEngine.coffee
@@ -21,6 +21,8 @@ define 'kryptnostic.kryptnostic-engine', [
   class KryptnosticEngine
 
     constructor: ({ @fhePrivateKey, @searchPrivateKey }) ->
+      unless Module? and Module.KryptnosticClient?
+        log.error(ENGINE_MISSING_ERROR)
 
     createClient: ->
       return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey)

--- a/js/src/engine/KryptnosticEngine.coffee
+++ b/js/src/engine/KryptnosticEngine.coffee
@@ -22,34 +22,37 @@ define 'kryptnostic.kryptnostic-engine', [
 
     constructor: ({ @fhePrivateKey, @searchPrivateKey }) ->
 
+    createClient: ->
+      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey)
+
     # indexing
     # ========
 
     getObjectSearchKey: ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectSearchKey()
+      return @createClient().getObjectSearchKey()
 
     getObjectAddressMatrix: ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectAddressMatrix()
+      return @createClient().getObjectAddressMatrix()
 
     getObjectIndexPair: ({ objectSearchKey, objectAddressMatrix }) ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectIndexPair(objectSearchKey, objectAddressMatrix)
+      return @createClient().getObjectIndexPair(objectSearchKey, objectAddressMatrix)
 
     getMetadatumAddress: ({ objectAddressFunction, token, objectSearchKey }) ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getMetadatumAddress(objectAddressFunction, objectSearchKey, token)
+      return @createClient().getMetadatumAddress(objectAddressFunction, objectSearchKey, token)
 
     # search
     # ======
 
     getEncryptedSearchToken: ({ token }) ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getEncryptedSearchToken(token)
+      return @createClient().getEncryptedSearchToken(token)
 
-    # share
-    # =====
+    # sharing
+    # =======
 
     getObjectSharingPair: ({ objectIndexPair }) ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectSharingPair(objectIndexPair)
+      return @createClient().getObjectSharingPair(objectIndexPair)
 
     getObjectIndexPairFromSharing: ({ objectSharingPair }) ->
-      return new Module.KryptnosticClient(@fhePrivateKey, @searchPrivateKey).getObjectUploadPair(objectSharingPair)
+      return @createClient().getObjectUploadPair(objectSharingPair)
 
   return KryptnosticEngine

--- a/js/src/engine/MockKryptnosticEngine.coffee
+++ b/js/src/engine/MockKryptnosticEngine.coffee
@@ -24,7 +24,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
     getObjectAddressMatrix: ->
       return BinaryUtils.stringToUint8(pad('doc.addressfun'))
 
-    getObjectIndexPair: (objectSearchKey, objectAddressFunction) ->
+    getObjectIndexPair: (objectSearchKey, objectAddressMatrix) ->
       return BinaryUtils.stringToUint8(pad('doc.index'))
 
     getMetadatumAddress: (objectAddressFunction, token, objectSearchKey) ->

--- a/js/src/engine/MockKryptnosticEngine.coffee
+++ b/js/src/engine/MockKryptnosticEngine.coffee
@@ -8,7 +8,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
   SPACE = ' '
 
   pad = (string) ->
-    if string.length % 2 is 0 then string else string + space
+    if string.length % 2 is 0 then string else string + SPACE
 
   #
   # Stand-in for the FHE engine which returns mocked values.
@@ -19,7 +19,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
   #
   class MockKryptnosticEngine
 
-    constructor: ({ @fhePrivateKey, @searchPrivateKey }) ->
+    constructor: ({ @fhePrivateKey, @searchPrivateKey } = {}) ->
 
     # indexing
     # ========
@@ -33,7 +33,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
     getObjectIndexPair: ({ objectSearchKey, objectAddressMatrix }) ->
       return BinaryUtils.stringToUint8(pad('doc.index'))
 
-    getMetadatumAddress: ({ objectAddressFunction, objectSearchKey, token }) ->
+    getMetadatumAddress: ({ objectAddressMatrix, objectSearchKey, token }) ->
       return BinaryUtils.stringToUint8('search.address.' + BinaryUtils.uint8ToString(token))
 
     # search

--- a/js/src/engine/MockKryptnosticEngine.coffee
+++ b/js/src/engine/MockKryptnosticEngine.coffee
@@ -8,10 +8,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
   SPACE = ' '
 
   pad = (string) ->
-    if string.length % 2 is 0
-      return string
-    else
-      return string + SPACE
+    if string.length % 2 is 0 then string else string + space
 
   #
   # Stand-in for the FHE engine which returns mocked values.
@@ -37,7 +34,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
       return BinaryUtils.stringToUint8(pad('doc.index'))
 
     getMetadatumAddress: ({ objectAddressFunction, objectSearchKey, token }) ->
-      return BinaryUtils.stringToUint8(pad('metadatum.address'))
+      return BinaryUtils.stringToUint8('search.address.' + BinaryUtils.uint8ToString(token))
 
     # search
     # ======
@@ -45,13 +42,13 @@ define 'kryptnostic.mock.kryptnostic-engine', [
     getEncryptedSearchToken: ({ token }) ->
       return BinaryUtils.stringToUint8(pad('search.token.' + BinaryUtils.uint8ToString(token)))
 
-    # share
-    # =====
+    # sharing
+    # =======
 
     getObjectSharingPair: ({ objectIndexPair }) ->
-      return BinaryUtils.stringToUint8(pad('doc.sharing.' + BinaryUtils.uint8ToString(objectIndexPair)))
+      return BinaryUtils.stringToUint8('doc.sharing.' + BinaryUtils.uint8ToString(objectIndexPair))
 
     getObjectIndexPairFromSharing: ({ objectSharingPair }) ->
-      return BinaryUtils.stringToUint8(pad('doc.upload.' + BinaryUtils.uint8ToString(objectUploadPair)))
+      return BinaryUtils.stringToUint8('doc.upload.' + BinaryUtils.uint8ToString(objectUploadPair))
 
   return MockKryptnosticEngine

--- a/js/src/engine/MockKryptnosticEngine.coffee
+++ b/js/src/engine/MockKryptnosticEngine.coffee
@@ -21,7 +21,7 @@ define 'kryptnostic.mock.kryptnostic-engine', [
     getObjectSearchKey: ->
       return BinaryUtils.stringToUint8(pad('doc.search'))
 
-    getObjectAddressFunction: ->
+    getObjectAddressMatrix: ->
       return BinaryUtils.stringToUint8(pad('doc.addressfun'))
 
     getObjectIndexPair: (objectSearchKey, objectAddressFunction) ->

--- a/js/src/engine/MockKryptnosticEngine.coffee
+++ b/js/src/engine/MockKryptnosticEngine.coffee
@@ -13,44 +13,36 @@ define 'kryptnostic.mock.kryptnostic-engine', [
   #
   class MockKryptnosticEngine
 
-    # client keys
-    # ===========
-
-    getFhePrivateKey: ->
-      return BinaryUtils.stringToUint8('fhe.priv')
-
-    getSearchPrivateKey: ->
-      return BinaryUtils.stringToUint8('search.pvt')
-
-    getClientHashFunction: ->
-      return BinaryUtils.stringToUint8('client.hashfun')
+    constructor: (@fhePrivateKey, @searchPrivateKey) ->
 
     # indexing
     # ========
 
-    getObjectSearchKey: (id) ->
-      return BinaryUtils.stringToUint8('doc.search')
+    getObjectSearchKey: ->
+      return BinaryUtils.stringToUint8(pad('doc.search'))
 
-    getObjectAddressFunction: (id) ->
-      return BinaryUtils.stringToUint8('doc.address')
+    getObjectAddressFunction: ->
+      return BinaryUtils.stringToUint8(pad('doc.addressfun'))
 
-    getObjectConversionMatrix: (id) ->
-      return BinaryUtils.stringToUint8('doc.conversion')
+    getObjectIndexPair: (objectSearchKey, objectAddressFunction) ->
+      return BinaryUtils.stringToUint8(pad('doc.index'))
 
-    getObjectIndexPair: (id) ->
-      return BinaryUtils.stringToUint8('doc.index')
-
-    # pair of docSearchKey, docAddressFunction
-    getObjectSharingPair: (id) ->
-      return BinaryUtils.stringToUint8('doc.sharing')
+    getMetadatumAddress: (objectAddressFunction, token, objectSearchKey) ->
+      return BinaryUtils.stringToUint8(pad('metadatum.address'))
 
     # search
     # ======
 
     getEncryptedSearchToken: (token) ->
-      return BinaryUtils.stringToUint8('search.token.' + BinaryUtils.uint8ToString(token))
+      return BinaryUtils.stringToUint8(pad('search.token.' + BinaryUtils.uint8ToString(token)))
 
-    getTokenAddress: (token, documentKey) ->
-      return BinaryUtils.stringToUint8('search.address.' + BinaryUtils.uint8ToString(token))
+    # share
+    # =====
+
+    getObjectSharingPair: (objectIndexPair) ->
+      return BinaryUtils.stringToUint8(pad('doc.sharing.' + BinaryUtils.uint8ToString(objectIndexPair)))
+
+    getObjectUploadPair: (objectSharingPair) ->
+      return BinaryUtils.stringToUint8(pad('doc.upload.' + BinaryUtils.uint8ToString(objectUploadPair)))
 
   return MockKryptnosticEngine

--- a/js/src/engine/MockSearchKeyGenerator.coffee
+++ b/js/src/engine/MockSearchKeyGenerator.coffee
@@ -5,15 +5,20 @@ define 'kryptnostic.mock.search-key-generator', [
 
   BinaryUtils = require 'kryptnostic.binary-utils'
 
+  pad = (string) ->
+    if string.length % 2 is 0 then string else string + SPACE
+
+  #
+  # Mock implementation of SearchKeyGenerator which returns static data.
+  # Keys are padded to ensure length is divisible by 2.
+  #
   class MockSearchKeyGenerator
 
-    # client keys
-    # ===========
-    getAllClientKeys: ->
+    generateClientKeys: ->
       return {
-        fhePrivateKey: BinaryUtils.stringToUint8(pad('fhe.priv'))
-        searchPrivateKey: BinaryUtils.stringToUint8(pad('search.pvt'))
-        clientHashFunction: BinaryUtils.stringToUint8(pad('hash.fun'))
+        fhePrivateKey      : BinaryUtils.stringToUint8(pad('fhe.priv'))
+        searchPrivateKey   : BinaryUtils.stringToUint8(pad('search.pvt'))
+        clientHashFunction : BinaryUtils.stringToUint8(pad('hash.fun'))
       }
 
-  return SearchKeyGenerator
+  return MockSearchKeyGenerator

--- a/js/src/engine/MockSearchKeyGenerator.coffee
+++ b/js/src/engine/MockSearchKeyGenerator.coffee
@@ -13,7 +13,7 @@ define 'kryptnostic.mock.search-key-generator', [
       return {
         fhePrivateKey: BinaryUtils.stringToUint8(pad('fhe.priv'))
         searchPrivateKey: BinaryUtils.stringToUint8(pad('search.pvt'))
-clientHashFunction: BinaryUtils.stringToUint8(pad('hash.fun'))
+        clientHashFunction: BinaryUtils.stringToUint8(pad('hash.fun'))
       }
 
   return SearchKeyGenerator

--- a/js/src/engine/MockSearchKeyGenerator.coffee
+++ b/js/src/engine/MockSearchKeyGenerator.coffee
@@ -1,0 +1,19 @@
+define 'kryptnostic.mock.search-key-generator', [
+  'require'
+  'kryptnostic.binary-utils'
+], (require) ->
+
+  BinaryUtils = require 'kryptnostic.binary-utils'
+
+  class MockSearchKeyGenerator
+
+    # client keys
+    # ===========
+    getAllClientKeys: ->
+      return {
+        fhePrivateKey: BinaryUtils.stringToUint8(pad('fhe.priv'))
+        searchPrivateKey: BinaryUtils.stringToUint8(pad('search.pvt'))
+clientHashFunction: BinaryUtils.stringToUint8(pad('hash.fun'))
+      }
+
+  return SearchKeyGenerator

--- a/js/src/engine/SearchKeyGenerator.coffee
+++ b/js/src/engine/SearchKeyGenerator.coffee
@@ -1,0 +1,21 @@
+define 'kryptnostic.search-key-generator', [
+  'require'
+  'kryptnostic.logger'
+], (require) ->
+
+  Logger = require 'kryptnostic.logger'
+
+  log = Logger.get('SearchKeyGenerator')
+
+  class SearchKeyGenerator
+
+    # client keys
+    # ===========
+    getAllClientKeys: ->
+      engine = new Module.KryptnosticClient()
+      return {
+        fhePrivateKey: engine.getPrivateKey()
+        searchPrivateKey: engine.getSearchPrivateKey()
+      }
+
+  return SearchKeyGenerator

--- a/js/src/engine/SearchKeyGenerator.coffee
+++ b/js/src/engine/SearchKeyGenerator.coffee
@@ -1,22 +1,18 @@
 define 'kryptnostic.search-key-generator', [
   'require'
-  'kryptnostic.logger'
 ], (require) ->
 
-  Logger = require 'kryptnostic.logger'
-
-  log = Logger.get('SearchKeyGenerator')
-
+  #
+  # Generates client keys needed for search.
+  #
   class SearchKeyGenerator
 
-    # client keys
-    # ===========
-    getAllClientKeys: ->
+    generateClientKeys: ->
       engine = new Module.KryptnosticClient()
       return {
-        fhePrivateKey: engine.getPrivateKey()
-        searchPrivateKey: engine.getSearchPrivateKey()
-        clientHashFunction: engine.getClientHashFunction()
+        fhePrivateKey      : engine.getPrivateKey()
+        searchPrivateKey   : engine.getSearchPrivateKey()
+        clientHashFunction : engine.getClientHashFunction()
       }
 
   return SearchKeyGenerator

--- a/js/src/engine/SearchKeyGenerator.coffee
+++ b/js/src/engine/SearchKeyGenerator.coffee
@@ -16,6 +16,7 @@ define 'kryptnostic.search-key-generator', [
       return {
         fhePrivateKey: engine.getPrivateKey()
         searchPrivateKey: engine.getSearchPrivateKey()
+        clientHashFunction: engine.getClientHashFunction()
       }
 
   return SearchKeyGenerator

--- a/js/src/engine/SearchKeyGenerator.coffee
+++ b/js/src/engine/SearchKeyGenerator.coffee
@@ -1,11 +1,27 @@
 define 'kryptnostic.search-key-generator', [
   'require'
+  'kryptnostic.logger'
 ], (require) ->
+
+  Logger = require 'kryptnostic.logger'
+
+  ENGINE_MISSING_ERROR = '''
+    KryptnosticClient is unavailable. This component must be included separately.
+    It is not built as a part of the kryptnostic.js binary. Please see the krytpnostic.js
+    documentation for more information and/or file an issue on the kryptnostic-js github project:
+    https://github.com/kryptnostic/kryptnostic-js/issues
+  '''
+
+  log = Logger.get('SearchKeyGenerator')
 
   #
   # Generates client keys needed for search.
   #
   class SearchKeyGenerator
+
+    constructor: ->
+      unless Module? and Module.KryptnosticClient?
+        log.error(ENGINE_MISSING_ERROR)
 
     generateClientKeys: ->
       engine = new Module.KryptnosticClient()

--- a/js/src/search/MetadataMapper.coffee
+++ b/js/src/search/MetadataMapper.coffee
@@ -35,11 +35,11 @@ define 'kryptnostic.search.metadata-mapper', [
   class MetadataMapper
 
     constructor: ->
-      @fheEngine      = new MockKryptnosticEngine()
+      @engine         = new MockKryptnosticEngine()
       @indexGenerator = new RandomIndexGenerator()
       @hashFunction   = HashFunction.MURMUR3_128
 
-    mapToKeys: ({ metadata, objectAddressFunction, objectSearchKey }) ->
+    mapToKeys: ({ metadata, objectAddressMatrix, objectSearchKey }) ->
       metadataMap  = {}
       bucketLength = computeBucketSize(metadata)
 
@@ -54,7 +54,11 @@ define 'kryptnostic.search.metadata-mapper', [
         tokenUint = BinaryUtils.hexToUint(tokenHex)
 
         # compute address of token
-        indexUint   = @fheEngine.getTokenAddress(tokenUint, objectAddressFunction, objectSearchKey)
+        indexUint   = @engine.getMetadatumAddress({
+          token : tokenUint,
+          objectAddressMatrix,
+          objectSearchKey
+        })
         indexString = BinaryUtils.uint8ToString(indexUint)
 
         # pad occurence locations

--- a/js/src/search/SearchClient.coffee
+++ b/js/src/search/SearchClient.coffee
@@ -1,9 +1,12 @@
 define 'kryptnostic.search-client', [
   'require'
+  'kryptnostic.binary-utils'
+  'kryptnostic.crypto-service-loader'
   'kryptnostic.mock.kryptnostic-engine'
   'kryptnostic.search-api'
 ], (require) ->
 
+  BinaryUtils           = require 'kryptnostic.binary-utils'
   CryptoServiceLoader   = require 'kryptnostic.crypto-service-loader'
   KryptnosticObject     = require 'kryptnostic.kryptnostic-object'
   MockKryptnosticEngine = require 'kryptnostic.mock.kryptnostic-engine'
@@ -18,14 +21,15 @@ define 'kryptnostic.search-client', [
   class SearchClient
 
     constructor: ->
-      @kryptnosticEngine   = new MockKryptnosticEngine()
+      @engine              = new MockKryptnosticEngine()
       @cryptoServiceLoader = new CryptoServiceLoader()
       @searchApi           = new SearchApi()
 
     search: (token) ->
       Promise.resolve()
       .then =>
-        encryptedToken = @kryptnosticEngine.getEncryptedSearchToken(token)
+        token = BinaryUtils.stringToUint8(token)
+        encryptedToken = @engine.getEncryptedSearchToken({ token })
         @searchApi.search(encryptedToken)
       .then (encryptedMetadata) ->
         Promise.all(_.map(encryptedMetadata, (encryptedMetadatum) =>

--- a/js/src/search/SearchIndexingService.coffee
+++ b/js/src/search/SearchIndexingService.coffee
@@ -83,7 +83,7 @@ define 'kryptnostic.search-indexing-service', [
         @cryptoServiceLoader.getObjectCryptoService(id, { expectMiss : false })
       .then (cryptoService) =>
         keyedMetadata = @metadataMapper.mapToKeys({
-          metadata, objectAddressFunction, objectSearchKey
+          metadata, objectAddressMatrix, objectSearchKey
         })
 
         metadataIndex = []

--- a/js/test/auth/SearchCredentialService-test.coffee
+++ b/js/test/auth/SearchCredentialService-test.coffee
@@ -124,10 +124,8 @@ define [
         sinon.stub(service.cryptoKeyStorageApi, 'getFhePrivateKey').returns(undefined)
         sinon.stub(service.cryptoKeyStorageApi, 'setFhePrivateKey', (key) ->
           storedKey = key
-
           service.cryptoKeyStorageApi.getFhePrivateKey.restore()
           sinon.stub(service.cryptoKeyStorageApi, 'getFhePrivateKey').returns(storedKey)
-
           return Promise.resolve()
         )
         service.getFhePrivateKey()

--- a/js/test/search/MetadataMapper-test.coffee
+++ b/js/test/search/MetadataMapper-test.coffee
@@ -46,7 +46,7 @@ define [
       it 'should pad all tokens to 128 bits with murmurhash3-128 before addressing', ->
         called   = false
         metadata = [ { id, locations: [0, 9], token: 'fish' }]
-        sinon.stub(metadataMapper.fheEngine, 'getTokenAddress', (token, documentKey) ->
+        sinon.stub(metadataMapper.engine, 'getMetadatumAddress', ({ token }) ->
           expect(token.length).toBe(PADDED_128_BIT_UINT8_ARRAY_LENGTH)
           expect(token instanceof Uint8Array).toBe(true)
           called = true
@@ -54,7 +54,7 @@ define [
         )
         metadataMapper.mapToKeys { metadata, documentKey }
         expect(called).toBe(true)
-        metadataMapper.fheEngine.getTokenAddress.restore()
+        metadataMapper.engine.getMetadatumAddress.restore()
 
       it 'should map metadata to their indexed locations', ->
         overwriteHashFunction(metadataMapper)

--- a/js/test/search/MetadataMapper-test.coffee
+++ b/js/test/search/MetadataMapper-test.coffee
@@ -31,15 +31,15 @@ define [
 
   describe 'MetadataMapper', ->
 
-    { kryptnosticEngine, metadataMapper, id, documentKey } = {}
+    { engine, metadataMapper, id, documentKey } = {}
 
     beforeEach ->
-      kryptnosticEngine = new MockKryptnosticEngine()
-      indexGenerator    = new StaticIndexGenerator()
-      metadataMapper    = new MetadataMapper()
-      _.extend(metadataMapper, { kryptnosticEngine, indexGenerator })
+      engine         = new MockKryptnosticEngine()
+      indexGenerator = new StaticIndexGenerator()
+      metadataMapper = new MetadataMapper()
+      _.extend(metadataMapper, { engine, indexGenerator })
       id          = 'some-object-id'
-      documentKey = kryptnosticEngine.getObjectSearchKey(id)
+      documentKey = engine.getObjectSearchKey(id)
 
     describe '#mapToKeys', ->
 


### PR DESCRIPTION
search part 4
==========
- adds `SearchKeyGenerator` and `MockSearchKeyGenerator`, with functions that match updated KryptnosticClient.js
- Changed `KryptnosticEngine` (and mock version) to always take private keys as inputs
- fixes unit tests
- refactors `SearchCredentialGenerator` to initialize all keys at once / updates public api
- makes unit tests for `SearchCredentialGenerator` more thorough
- updates all terminology to be consistent when referencing various keys/tokens used from the `KryptnosticClient` implementations.