### PR TITLE
RSA public key was being set as the string [Object object] in IE11

### DIFF
--- a/compile-exports.rb
+++ b/compile-exports.rb
@@ -6,9 +6,9 @@
 #
 
 JS_LIB_EXPORTS = [
-  'bluebird',
   'axios',
   'base64',
+  'bluebird',
   'forge',
   'jscache',
   'lodash',

--- a/js/src/http/KeyStorageApi.coffee
+++ b/js/src/http/KeyStorageApi.coffee
@@ -288,10 +288,10 @@ define 'kryptnostic.key-storage-api', [
       publicKeyAsUint8 = BinaryUtils.stringToUint8(publicKey)
 
       #
-      # axios converts the Uint8Array into a DataView before sending the request. it's unclear why, but IE 11 transforms this
-      # DataView and sends the string "[Object object]" instead of the actual binary data. I've posted a question on
-      # StackOverflow to get an explanation of why IE 11 breaks in such a way.
+      # axios converts the Uint8Array into a DataView before sending the request. it's unclear why, but IE 11
+      # transforms this DataView and sends the string "[Object object]" instead of the actual binary data.
       #
+      # I've posted a question on StackOverflow to get an explanation of why IE 11 breaks in such a way.
       # http://stackoverflow.com/questions/36042069/cant-post-binary-data-as-a-dataview-in-ie-11
       #
       # as a workaround for this request, we'll avoid axios and use XMLHttpRequest directly with the Uint8Array

--- a/js/src/util/requests.coffee
+++ b/js/src/util/requests.coffee
@@ -72,6 +72,8 @@ define 'kryptnostic.requests', [
         return null
 
   return {
+    PRINCIPAL_HEADER,
+    CREDENTIAL_HEADER,
     wrapCredentials,
     getAsUint8FromUrl,
     getBlockCiphertextFromUrl


### PR DESCRIPTION
for reference:

http://stackoverflow.com/questions/36042069/cant-post-binary-data-as-a-dataview-in-ie-11
https://github.com/mzabriskie/axios/issues/268