### PR TITLE
route object GETs to cdn.kodex.im (CloudFlare cache)

### DIFF
--- a/js/src/crypto/CryptoServiceLoader.coffee
+++ b/js/src/crypto/CryptoServiceLoader.coffee
@@ -79,7 +79,7 @@ define 'kryptnostic.crypto-service-loader', [
         Cache.store(Cache.CRYPTO_SERVICES, Cache.MASTER_AES_CRYPTO_SERVICE, masterAesCryptoService)
         return masterAesCryptoService
 
-    getObjectCryptoServiceV2: (versionedObjectKey, options) ->
+    getObjectCryptoService: (versionedObjectKey, options) ->
       options        = _.defaults({}, options, DEFAULT_OPTS)
       { expectMiss } = options
 
@@ -97,7 +97,7 @@ define 'kryptnostic.crypto-service-loader', [
         if !cryptoServiceBlockCiphertext && expectMiss
           log.info('no cryptoService exists for this object. creating one on-the-fly', { objectId })
           objectCryptoService = new AesCryptoService(Cypher.AES_GCM_256)
-          @setObjectCryptoServiceV2(versionedObjectKey, objectCryptoService, masterAesCryptoService)
+          @setObjectCryptoService(versionedObjectKey, objectCryptoService, masterAesCryptoService)
         else if !cryptoServiceBlockCiphertext && !expectMiss
           log.error('no cryptoservice exists for this object, but a miss was not expected')
           return null
@@ -107,7 +107,7 @@ define 'kryptnostic.crypto-service-loader', [
           @cache[objectId] = objectCryptoService
         return objectCryptoService
 
-    setObjectCryptoServiceV2: (versionedObjectKey, objectCryptoService, masterAesCryptoService) ->
+    setObjectCryptoService: (versionedObjectKey, objectCryptoService, masterAesCryptoService) ->
       unless objectCryptoService._CLASS_NAME is AesCryptoService._CLASS_NAME
         throw new Error('support is only implemented for AesCryptoService')
 

--- a/js/src/crypto/CryptoServiceMigrator.coffee
+++ b/js/src/crypto/CryptoServiceMigrator.coffee
@@ -43,7 +43,7 @@ define 'kryptnostic.crypto-service-migrator', [
 
   logger = Logger.get('CryptoServiceMigrator')
 
-  keyStorageApi = -> Config.get('servicesUrlV2') + '/keys'
+  keyStorageApi = -> Config.get('servicesUrl') + '/keys'
   rsaCryptoServicesBulkUrl = -> keyStorageApi() + '/bulk/cryptoservices'
   aesCryptoServiceMigrationUrl = (objectId) -> keyStorageApi() + '/aes/cryptoservice-migration/id/' + objectId
 

--- a/js/src/http/KeyStorageApi.coffee
+++ b/js/src/http/KeyStorageApi.coffee
@@ -44,42 +44,56 @@ define 'kryptnostic.key-storage-api', [
   logger = Logger.get('KeyStorageApi')
 
   keyStorageApi = -> Config.get('servicesUrl') + '/keys'
+  keyStorageApiCdn = -> Config.get('servicesCdnUrl') + '/keys'
 
   #
   # FHE endpoints
   #
 
-  fheKeysUrl             = -> keyStorageApi() + '/fhe'
-  fheHashUrl             = -> fheKeysUrl() + '/hash'
-  fhePrivateKeyUrl       = -> fheKeysUrl() + '/private'
+  fheKeysUrl = -> keyStorageApi() + '/fhe'
+  fheKeysCdnUrl = -> keyStorageApiCdn() + '/fhe'
+
+  fheHashUrl = -> fheKeysUrl() + '/hash'
+  fheHashCdnUrl = -> fheKeysCdnUrl() + '/hash'
+
+  fhePrivateKeyUrl = -> fheKeysUrl() + '/private'
+  fhePrivateKeyCdnUrl = -> fheKeysCdnUrl() + '/private'
+
   fheSearchPrivateKeyUrl = -> fheKeysUrl() + '/searchprivate'
+  fheSearchPrivateKeyCdnUrl = -> fheKeysCdnUrl() + '/searchprivate'
 
   #
   # salt endpoints
   #
 
   saltUrl = (userId) -> keyStorageApi() + '/salt/' + userId
+  saltCdnUrl = (userId) -> keyStorageApiCdn() + '/salt/' + userId
 
   #
   # RSA endpoints
   #
 
-  rsaKeysUrl         = -> keyStorageApi() + '/rsa'
-  rsaPrivateKeyUrl   = -> rsaKeysUrl() + '/private'
+  rsaKeysUrl = -> keyStorageApi() + '/rsa'
+  rsaKeysCdnUrl = -> keyStorageApiCdn() + '/rsa'
+
+  rsaPrivateKeyUrl = -> rsaKeysUrl() + '/private'
   setRSAPublicKeyUrl = -> rsaKeysUrl() + '/public'
   getRSAPublicKeyUrl = (userId) -> rsaKeysUrl() + '/public/' + userId
+  getRSAPublicKeyCdnUrl = (userId) -> rsaKeysCdnUrl() + '/public/' + userId
   getRSAPublicKeyBulkUrl = -> rsaKeysUrl() + '/public/bulk'
 
   #
   # crypto service endpoints
   #
 
-  # cryptoServiceUrl  = (objectId, objectVersion) ->
-  #   keyStorageApi() + '/cryptoservice/id/' + objectId + '/' + objectVersion
-
   aesUrl = -> keyStorageApi() + '/aes'
+  aesCdnUrl = -> keyStorageApiCdn() + '/aes'
+
   aesCryptoServiceUrl = (objectId, objectVersion) ->
     aesUrl() + '/cryptoservice/id/' + objectId + '/' + objectVersion
+
+  aesCryptoServiceCdnUrl = (objectId, objectVersion) ->
+    aesCdnUrl() + '/cryptoservice/id/' + objectId + '/' + objectVersion
 
   #
   # helper functions
@@ -96,7 +110,7 @@ define 'kryptnostic.key-storage-api', [
 
     @getFHEPrivateKey: ->
       Requests.getBlockCiphertextFromUrl(
-        fhePrivateKeyUrl()
+        fhePrivateKeyCdnUrl()
       )
 
     @setFHEPrivateKey: (fhePrivateKey) ->
@@ -117,7 +131,7 @@ define 'kryptnostic.key-storage-api', [
 
     @getFHESearchPrivateKey: ->
       Requests.getBlockCiphertextFromUrl(
-        fheSearchPrivateKeyUrl()
+        fheSearchPrivateKeyCdnUrl()
       )
 
     @setFHESearchPrivateKey: (fheSearchPrivateKey) ->
@@ -267,7 +281,7 @@ define 'kryptnostic.key-storage-api', [
         return Promise.resolve(null)
 
       Requests.getAsUint8FromUrl(
-        getRSAPublicKeyUrl(userId)
+        getRSAPublicKeyCdnUrl(userId)
       )
 
     @setRSAPublicKey: (publicKey) ->
@@ -304,7 +318,7 @@ define 'kryptnostic.key-storage-api', [
         axios(
           Requests.wrapCredentials({
             method : 'GET',
-            url    : aesUrl()
+            url    : aesCdnUrl()
           })
         )
       )
@@ -356,7 +370,7 @@ define 'kryptnostic.key-storage-api', [
         return Promise.resolve(cachedObjectCryptoService)
 
       Requests.getBlockCiphertextFromUrl(
-        aesCryptoServiceUrl(versionedObjectKey.objectId, versionedObjectKey.objectVersion)
+        aesCryptoServiceCdnUrl(versionedObjectKey.objectId, versionedObjectKey.objectVersion)
       )
       .then (objectCryptoServiceBlockCiphertext) ->
         if objectCryptoServiceBlockCiphertext

--- a/js/src/http/KeyStorageApi.coffee
+++ b/js/src/http/KeyStorageApi.coffee
@@ -43,7 +43,7 @@ define 'kryptnostic.key-storage-api', [
 
   logger = Logger.get('KeyStorageApi')
 
-  keyStorageApi = -> Config.get('servicesUrlV2') + '/keys'
+  keyStorageApi = -> Config.get('servicesUrl') + '/keys'
 
   #
   # FHE endpoints

--- a/js/src/http/ObjectApi.coffee
+++ b/js/src/http/ObjectApi.coffee
@@ -36,14 +36,20 @@ define 'kryptnostic.object-api', [
 
   logger = Logger.get('ObjectApi')
 
-  objectUrl         = -> Config.get('servicesUrl') + '/object'
-  objectsUrl        = -> objectUrl() + '/bulk'
-  objectIdUrl       = (objectId) -> objectUrl() + '/id/' + objectId
+  objectUrl = -> Config.get('servicesUrl') + '/object'
+  objectCdnUrl = -> Config.get('servicesCdnUrl') + '/object'
+
+  objectIdUrl = (objectId) -> objectUrl() + '/id/' + objectId
+  objectIdCdnUrl = (objectId) -> objectCdnUrl() + '/id/' + objectId
+
+  objectVersionUrl = (objectId, objectVersion) -> objectIdUrl(objectId) + '/' + objectVersion
+  objectVersionCdnUrl  = (objectId, objectVersion) -> objectIdCdnUrl(objectId) + '/' + objectVersion
+
   latestObjectIdUrl = (objectId) -> objectUrl() + '/latest/id/' + objectId
   objectMetadataUrl = (objectId) -> objectUrl() + '/objectmetadata/id/' + objectId
-  objectVersionUrl  = (objectId, objectVersion) -> objectIdUrl(objectId) + '/' + objectVersion
-  objectLevelsUrl   = -> objectUrl() + '/levels'
-  indexSegmentUrl   = -> objectUrl() + '/index-segment'
+  bulkObjectsUrl = -> objectUrl() + '/bulk'
+  objectLevelsUrl = -> objectUrl() + '/levels'
+  indexSegmentUrl = -> objectUrl() + '/index-segment'
 
   class ObjectApi
 
@@ -71,7 +77,7 @@ define 'kryptnostic.object-api', [
         axios(
           Requests.wrapCredentials({
             method  : 'POST'
-            url     : objectsUrl()
+            url     : bulkObjectsUrl()
             data    : JSON.stringify(objectIds)
             headers : DEFAULT_HEADERS
           })
@@ -195,7 +201,7 @@ define 'kryptnostic.object-api', [
 
     getObjectAsBlockCiphertext: (versionedObjectKey) ->
       Requests.getBlockCiphertextFromUrl(
-        objectVersionUrl(versionedObjectKey.objectId, versionedObjectKey.objectVersion)
+        objectVersionCdnUrl(versionedObjectKey.objectId, versionedObjectKey.objectVersion)
       )
 
     setObjectFromBlockCiphertext: (versionedObjectKey, blockCiphertext) ->

--- a/js/src/http/ObjectApi.coffee
+++ b/js/src/http/ObjectApi.coffee
@@ -36,7 +36,7 @@ define 'kryptnostic.object-api', [
 
   logger = Logger.get('ObjectApi')
 
-  objectUrl         = -> Config.get('servicesUrlV2') + '/object'
+  objectUrl         = -> Config.get('servicesUrl') + '/object'
   objectsUrl        = -> objectUrl() + '/bulk'
   objectIdUrl       = (objectId) -> objectUrl() + '/id/' + objectId
   latestObjectIdUrl = (objectId) -> objectUrl() + '/latest/id/' + objectId

--- a/js/src/http/ObjectAuthorizationApi.coffee
+++ b/js/src/http/ObjectAuthorizationApi.coffee
@@ -27,7 +27,7 @@ define 'kryptnostic.object-authorization-api', [
     validateUuid
   } = Validators
 
-  accessUrl  = -> Config.get('servicesUrlV2') + '/access'
+  accessUrl  = -> Config.get('servicesUrl') + '/access'
   ownersUrl  = (objectId) -> accessUrl() + '/owners/' + objectId
   readersUrl = (objectId) -> accessUrl() + '/readers/' + objectId
   writersUrl = (objectId) -> accessUrl() + '/writers/' + objectId

--- a/js/src/http/ObjectListingApi.coffee
+++ b/js/src/http/ObjectListingApi.coffee
@@ -21,7 +21,7 @@ define 'kryptnostic.object-listing-api', [
 
   logger = Logger.get('ObjectListingApi')
 
-  objectListingApi    = -> Config.get('servicesUrlV2') + '/listing'
+  objectListingApi    = -> Config.get('servicesUrl') + '/listing'
   objectsUrl          = -> objectListingApi() + '/objects'
   versionedObjectsUrl = -> objectListingApi() + '/versioned/objects'
 

--- a/js/src/http/RegistrationApi.coffee
+++ b/js/src/http/RegistrationApi.coffee
@@ -9,7 +9,7 @@ define 'kryptnostic.registration-api', [
   Promise       = require 'bluebird'
   Configuration = require 'kryptnostic.configuration'
 
-  registrationUrl = -> Configuration.get('heraclesUrlV2') + '/registration/user'
+  registrationUrl = -> Configuration.get('heraclesUrl') + '/registration/user'
 
 
   DEFAULT_HEADERS = { 'Content-Type' : 'application/json' }

--- a/js/src/http/SearchApi.coffee
+++ b/js/src/http/SearchApi.coffee
@@ -22,7 +22,7 @@ define 'kryptnostic.search-api', [
 
   { validateVersionedObjectKey } = Validators
 
-  searchUrl       = -> Configuration.get('servicesUrlV2') + '/search'
+  searchUrl       = -> Configuration.get('servicesUrl') + '/search'
   segmentRangeUrl = (objectId, count) -> searchUrl() + '/' + objectId + '/' + count
 
   logger = Logger.get('SearchApi')

--- a/js/src/http/SharingApi.coffee
+++ b/js/src/http/SharingApi.coffee
@@ -29,7 +29,7 @@ define 'kryptnostic.sharing-api', [
 
   logger = Logger.get('SharingApi')
 
-  sharingUrl             = -> Config.get('servicesUrlV2') + '/share'
+  sharingUrl             = -> Config.get('servicesUrl') + '/share'
   shareKeysUrl           = -> sharingUrl() + '/keys'
   shareObjectUrl         = -> sharingUrl() + '/object'
   revokeObjectUrl        = -> shareObjectUrl()

--- a/js/src/http/UserDirectoryApi.coffee
+++ b/js/src/http/UserDirectoryApi.coffee
@@ -18,11 +18,11 @@ define 'kryptnostic.user-directory-api', [
   Requests      = require 'kryptnostic.requests'
   Validators    = require 'kryptnostic.validators'
 
-  getUserUrl   = -> Configuration.get('heraclesUrlV2') + '/directory/user'
-  getUsersUrl  = -> Configuration.get('heraclesUrlV2') + '/directory/users'
-  usersInRealmUrl = -> Configuration.get('heraclesUrlV2') + '/directory'
-  setFirstLoginUrl = -> Configuration.get('heraclesUrlV2') + '/directory/setlogin'
-  getUserIdFromEmail = (email) -> Configuration.get('heraclesUrlV2') + '/directory/validate/sharing/email/' + email
+  getUserUrl   = -> Configuration.get('heraclesUrl') + '/directory/user'
+  getUsersUrl  = -> Configuration.get('heraclesUrl') + '/directory/users'
+  usersInRealmUrl = -> Configuration.get('heraclesUrl') + '/directory'
+  setFirstLoginUrl = -> Configuration.get('heraclesUrl') + '/directory/setlogin'
+  getUserIdFromEmail = (email) -> Configuration.get('heraclesUrl') + '/directory/validate/sharing/email/' + email
 
   log = Logger.get('UserDirectoryApi')
 

--- a/js/src/indexing/ObjectIndexingService.coffee
+++ b/js/src/indexing/ObjectIndexingService.coffee
@@ -110,7 +110,7 @@ define 'kryptnostic.indexing.object-indexing-service', [
       # 3. reserve a range of integers for each inverted index segment
       Promise.props({
         objectSearchPair: @sharingApi.getObjectSearchPair(parentObjectKey),
-        objectCryptoService: @cryptoServiceLoader.getObjectCryptoServiceV2(parentObjectKey),
+        objectCryptoService: @cryptoServiceLoader.getObjectCryptoService(parentObjectKey),
         segmentRangeStartIndex: SearchApi.reserveSegmentRange(parentObjectKey, invertedIndexSegments.length)
       })
       .then ({ objectSearchPair, objectCryptoService, segmentRangeStartIndex }) =>

--- a/js/src/search/SearchClient.coffee
+++ b/js/src/search/SearchClient.coffee
@@ -73,7 +73,7 @@ define 'kryptnostic.search-client', [
 
             objectIdSet.push(objectId)
             invertedIndexSegmentsPromise = @objectApi.getObjects(invertedIndexSegmentIds)
-            objectCryptoServicePromise = @cryptoServiceLoader.getObjectCryptoServiceV2(
+            objectCryptoServicePromise = @cryptoServiceLoader.getObjectCryptoService(
               {
                 objectId: objectId,
                 objectVersion: 0 # !!! HACK !!! we're hardcoding version 0 for now

--- a/js/src/service/ConfigurationService.coffee
+++ b/js/src/service/ConfigurationService.coffee
@@ -8,8 +8,6 @@ define 'kryptnostic.configuration', [
   log    = Logger.get('ConfigurationService')
 
   DEFAULTS = {
-    servicesUrl        : 'http://api.kryptnostic.com/v2'
-    heraclesUrl        : 'https://api.kryptnostic.com/heracles/v2'
     credentialProvider : 'kryptnostic.credential-provider.local-storage'
     cachingProvider    : 'kryptnostic.caching-provider.jscache'
   }

--- a/js/src/service/ConfigurationService.coffee
+++ b/js/src/service/ConfigurationService.coffee
@@ -8,10 +8,8 @@ define 'kryptnostic.configuration', [
   log    = Logger.get('ConfigurationService')
 
   DEFAULTS = {
-    servicesUrl        : 'http://api.kryptnostic.com/v1'
-    servicesUrlV2      : 'http://api.kryptnostic.com/v2'
-    heraclesUrl        : 'https://api.kryptnostic.com/heracles/v1'
-    heraclesUrlV2      : 'https://api.kryptnostic.com/heracles/v2'
+    servicesUrl        : 'http://api.kryptnostic.com/v2'
+    heraclesUrl        : 'https://api.kryptnostic.com/heracles/v2'
     credentialProvider : 'kryptnostic.credential-provider.local-storage'
     cachingProvider    : 'kryptnostic.caching-provider.jscache'
   }

--- a/js/src/service/SharingClient.coffee
+++ b/js/src/service/SharingClient.coffee
@@ -97,7 +97,7 @@ define 'kryptnostic.sharing-client', [
 
       Promise.join(
         sharingApi.getObjectSearchPair(objectKey),
-        cryptoServiceLoader.getObjectCryptoServiceV2(objectKey),
+        cryptoServiceLoader.getObjectCryptoService(objectKey),
         KeyStorageApi.getRSAPublicKeys(uuids),
         (objectSearchPair, objectCryptoService, uuidsToRsaPublicKeys) ->
 
@@ -172,7 +172,7 @@ define 'kryptnostic.sharing-client', [
 
               Promise.all([
                 @sharingApi.addObjectSearchPair(objectKey, objectSearchPair),
-                @cryptoServiceLoader.setObjectCryptoServiceV2(objectKey, objectCryptoService, masterAesCryptoService)
+                @cryptoServiceLoader.setObjectCryptoService(objectKey, objectCryptoService, masterAesCryptoService)
               ])
               .then =>
                 @sharingApi.removeIncomingShare(objectKey)

--- a/js/src/service/StorageClient.coffee
+++ b/js/src/service/StorageClient.coffee
@@ -63,9 +63,9 @@ define 'kryptnostic.storage-client', [
 
         cryptoServicePromise = null
         if parentObjectKey?
-          cryptoServicePromise = @cryptoServiceLoader.getObjectCryptoServiceV2(parentObjectKey)
+          cryptoServicePromise = @cryptoServiceLoader.getObjectCryptoService(parentObjectKey)
         else
-          cryptoServicePromise = @cryptoServiceLoader.getObjectCryptoServiceV2(objectKey)
+          cryptoServicePromise = @cryptoServiceLoader.getObjectCryptoService(objectKey)
 
         Promise.props({
           blockCiphertext : @objectApi.getObjectAsBlockCiphertext(objectKey),
@@ -101,7 +101,7 @@ define 'kryptnostic.storage-client', [
         promises = []
         _.forEach(objectKeys, (objectKey) =>
           promise = Promise.join(
-            @cryptoServiceLoader.getObjectCryptoServiceV2(objectKey),
+            @cryptoServiceLoader.getObjectCryptoService(objectKey),
             @objectApi.getObjectAsBlockCiphertext(objectKey)
           )
           .then (objectMaterial) ->
@@ -147,7 +147,7 @@ define 'kryptnostic.storage-client', [
       .then (parentObjectKey) =>
 
         Promise.props({
-          objectCryptoService    : @cryptoServiceLoader.getObjectCryptoServiceV2(parentObjectKey)
+          objectCryptoService    : @cryptoServiceLoader.getObjectCryptoService(parentObjectKey)
           objectBlockCiphertexts : @objectApi.getObjects(objectIds)
         })
         .then ({ objectBlockCiphertexts, objectCryptoService }) ->
@@ -171,7 +171,7 @@ define 'kryptnostic.storage-client', [
       )
       .then (parentObjectKey) =>
         Promise.props({
-          objectCryptoService : @cryptoServiceLoader.getObjectCryptoServiceV2(parentObjectKey)
+          objectCryptoService : @cryptoServiceLoader.getObjectCryptoService(parentObjectKey)
           objectMetadataTrees : @objectApi.getObjectsByTypeAndLoadLevel(
             objectIds,
             typeLoadLevels,
@@ -226,7 +226,7 @@ define 'kryptnostic.storage-client', [
           .then (objectKeyForNewlyCreatedObject) =>
             parentObjectKey = if parentObjectKey? then parentObjectKey else objectKeyForNewlyCreatedObject
             Promise.resolve(
-              @cryptoServiceLoader.getObjectCryptoServiceV2(
+              @cryptoServiceLoader.getObjectCryptoService(
                 parentObjectKey,
                 { expectMiss : true }
               )
@@ -279,7 +279,7 @@ define 'kryptnostic.storage-client', [
       )
       .then (latestObjectKey) =>
         Promise.resolve(
-          @cryptoServiceLoader.getObjectCryptoServiceV2(versionedObjectKey)
+          @cryptoServiceLoader.getObjectCryptoService(versionedObjectKey)
         )
         .then (objectCryptoService) =>
           # ToDo: for now, we encrypt the entire object, but we'll need to support encrypting an object in chunks

--- a/js/test/service/ConfigurationService-test.coffee
+++ b/js/test/service/ConfigurationService-test.coffee
@@ -6,9 +6,8 @@ define [
   ConfigurationService = require 'kryptnostic.configuration'
 
   EXPECTED_DEFAULTS = {
-    servicesUrl        : 'http://api.kryptnostic.com/v1'
-    servicesUrlV2      : 'http://api.kryptnostic.com/v2'
-    heraclesUrl        : 'https://api.kryptnostic.com/heracles/v1'
+    servicesUrl        : 'http://api.kryptnostic.com/v2'
+    heraclesUrl        : 'https://api.kryptnostic.com/heracles/v2'
     credentialProvider : 'kryptnostic.credential-provider.local-storage'
     cachingProvider    : 'kryptnostic.caching-provider.jscache'
   }


### PR DESCRIPTION
Tier 1 URLs
- `/object/id/(id)/(version)`
- `/keys/aes`
- `/keys/aes/cryptoservice/id/(id)/(version)`

Tier 2 URLs
- `/keys/fhe/private`
- `/keys/fhe/searchprivate`
- `/keys/rsa/public/(id)`